### PR TITLE
Add a custom deb-builder workflow to build the package in CI

### DIFF
--- a/.github/workflows/deb-builder.yml
+++ b/.github/workflows/deb-builder.yml
@@ -1,0 +1,16 @@
+on: push
+
+jobs:
+  build-debs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jtdor/build-deb-action@v1
+        env:
+          DEB_BUILD_OPTIONS: noautodbgsym
+        with:
+          buildpackage-opts: --build=binary --no-sign
+          host-arch: arm64
+          apt-opts: --install-recommends
+          extra-build-deps: ca-certificates
+

--- a/.github/workflows/deb-builder.yml
+++ b/.github/workflows/deb-builder.yml
@@ -13,4 +13,66 @@ jobs:
           host-arch: arm64
           apt-opts: --install-recommends
           extra-build-deps: ca-certificates
-
+          apt-sources: |
+            Types: deb
+            URIs: https://feeds.toradex.com/debian
+            Suites: testing
+            Components: main non-free
+            Signed-By: /usr/share/keyrings/build-deb-action.gpg
+          apt-key: |
+            -----BEGIN PGP PUBLIC KEY BLOCK-----
+            
+            mQINBGUJ0fgBEADe+nvFNajvFQQPGXXLixVz4/+xLGdnmgGef6Oe4DPuIFD7WATJ
+            hzH8ng+elAHVIkfrV7+j9lGWnozcBqBdvHoz46Y2EE1nk3no78aUdy+9b0wx3yWe
+            tqY29Nu3yVD8d64e5fuGq4PKJB1gtFkWhEfFwTmq3uiRQRfAy60DERTDF7bocQsW
+            hTVjc/Lr1lj4POB0HlUhzIj84o/y5SV50F0oqpJdjfu6Bbp/XVHklF4GNBabaFVf
+            iF11306eWKcKM2yZI4MJhAPTaTSFS51Z81lbQkyLjQzfdxAvSSsNWUUS8A3IYBhi
+            IwyeIS3jPtBcIDPcxKDB8rio8j6eKq0FtnW1WTVMmDdBqLlE71y2Av2d2W4ySqf+
+            huvhRPqCVMgsr09oHUOka19cX82YTYiMOU3/+UsKZ2DJT0w+k2z5DOirzf5SNbcA
+            hlc8WcjavrYTqVysB7IIQx+WsYosRXOSWMmbY+3fk5lpnz/ZZfluiz36krdYxIdd
+            MtiaUtrRZvj0hpbe85alUaqVJ87k1TrA5URpXV0ZOgV753QWOtjcclEroRIINEzZ
+            bwBjZlRrPFos/VSbsx0/2MTEkxLI/bakOihpZ53f4uhwrv8Kc7+lDLP51N8t2UAM
+            sORmkLsNQUdCxM8Ary+fl2h1DvvgqxE2F3uzIrpM8DgGC0+Ln8jS+vEgBQARAQAB
+            tChUb3JhZGV4IEFHIDxkZWJpYW4tcGtnLXRlYW1AdG9yYWRleC5jb20+iQJOBBMB
+            CgA4FiEExxIbHghPt0MdjZudxpwk2XUKkDAFAmUJ0fgCGwMFCwkIBwIGFQoJCAsC
+            BBYCAwECHgECF4AACgkQxpwk2XUKkDBmAhAAklMNV3sAN4fGfBmgOLQDkJJE6plL
+            qAbV9NeRJ1XN4SfDY9K7b/7K3HYmge9ojj/tVcISYIflehkFJBVhj8gK+9EH74xW
+            PHz711i4hqRvAfHFbjJNhluDdiYmqHnF6OWHffr1DrSYZ32WykcSl4Iy0VU2LRZA
+            92kAokZwTLFQNQQLW0lZSTtyyFfQPbtuk+7RBHTOcbr0HYojM41Poj4rpOiAhgmS
+            gZlO1G39s/efPKJGXfr1jZdCVJP8yVG3A3tcYMhR5mwrZ6oVR5Rup8JTrHCenGhK
+            +gwgtqzRhuLwX9GOsxbJyCnPkZv694bu3Epaz8b+jeB9jAHSnLlv6QH+BtVcJbg7
+            vIRiykaLgx1M/goeTMLGEyHPgWbXYJmqeoRXMwkAsRFTPUzgBC5CaAniDiLSQ726
+            ppW9l5YHgozU/eaaxqkPjRFrEUqFgN919CW4NwX65L2ENIdH2AMF4AumFFEtmw8l
+            nPul2VCUHlA1+i31KiO5l0tNituPVolp/Gh/nmTnKNTaU7xp1B7Ph001x0q54k6l
+            GebRSj+d+pzAvzuy1GKSKIMqYUv4pfJyEZq1jRJe4faLxXCdIADbfo5UqOD+A2L3
+            QqLwRypTW8gYRjnPWar33xo1Y2QQ1bbn3+Kp+h27hWvUmimlwdf+xz0VFtAPiBlp
+            pdViHFsGt78rMFC5Ag0EZQnR+AEQAMedkYK5MHNu0dwnVAIIXLfxHWHOtLp2r31A
+            k+DsOJjVM3ob3iJ1I3AOJFTtNem6r8dXXfYYFiABe9eIAKY1xwVw6TSgCisLkvGn
+            pzE/Ul2GXBjWmZTnoqm4eNft3r7VyjvV6qplEdHjneaYnKsAsJDN+/zfnYiNnl0D
+            ikYWPTe27/kSQsOgA6rr3wBs//FGF0kgl9T4+EKzsDpDsiJMu9fjEeiW5z3SrTVQ
+            VGG34ikG3IRpwJYsBLSLjBXYW8DU8d4p8aNKCkqchJv8ymaoOsSfx3HLGH359AxB
+            4fsWJSKHH2RmQ6pHbaWM3A7XrR1zn3vb3yn5dzdkCchTtdgvYUgC5T8d75WYzMWp
+            1LCvdxnTXUoECFXGWBicq8bw42bfiw4929T3PtWpFqvPLBlMlZBqTNBW65mvGkeP
+            aChgq4A4sxLQcfAkQf5S0woss1W3wJ/04XjoLNm0XYwTEepe5Mva//NmHwMBIpN6
+            pKE2VmnzPBJXbwU0TAcfhbXR9IEUk8RUcxwaCThcBh4Oie6+ZusVevcoS8UjGF08
+            3IFJV/mJZAdNZvcaNuHTcdHIPi3dD/M3nkjeK0kDj+Exg1Lct/UbDO6NidE7Ayte
+            rRmZETngxeeo4S1gmdteKulKmHcu/IvN+xhSkettuIYWJq7jwfglxakIcCIOY8yw
+            8zpF4+ZZABEBAAGJAjYEGAEKACAWIQTHEhseCE+3Qx2Nm53GnCTZdQqQMAUCZQnR
+            +AIbDAAKCRDGnCTZdQqQMChiEADGSFk2G0QrGDRg489okGz31mNa9ggISNREkIY8
+            MUZ/rbdeOdG66EMVW/zLmNTYbEZdJrYbLSO1zRznACWD1wuvqsFn3q0sG3a/VnVE
+            wx38h6sD7lizqSSotneQUhm5EVAoA0D0V8xYz5oPvogFifHs0TBEaPHGQ8Xy88Ep
+            tnGceKfceroS2z6pehZDGpSMpSgNIkJ8ay2aTZEF4A21uUGZSmB6nfUWmGob1/yk
+            t7OFIVpO+1QTVa3MyfxwUSDriQtjhVkV7Kj5R06UmuDibj/LFlhK2Nn1NpZY2yjH
+            yjPrwDZiqfWhuP5XyvVHAXJT2Am7e+wt1odQMBjtytAQ1UmpamTiKZMIsU/lh/qV
+            5D0Rb8GPJXn0YqgoUTqa8uGbExdEfNxnoegcF2wUaOQoZk9yjOQc26QRV/6QVO5M
+            th41p/ZxuTPVJAs76MPPpeNFT9xZmsP+LWE2awaWYTTk+aAmgQQIHyqJqc/QRYsw
+            KKcWF/U+7aKlt2J24v7RFIMkNSRL9UiYcNhMgIJVIw2NkWlF4LoDRQ8l8DMD4St3
+            eKYPMo0laD2+Z4ul7hUjY7pHSDSO+erfySkFpvx83XgtF9d0uJdMXQ3gRuFhwtK7
+            Grl7Vu/9cvNCWtBq5/hNdGU1d4Y1HoAK6sooRbwy0JUaXHq08MDhpWQysmPpHBKX
+            CvvuQQ==
+            =VfKA
+            -----END PGP PUBLIC KEY BLOCK-----
+          apt-preferences: |
+            Package: *
+            Pin: origin feeds.toradex.com
+            Pin-Priority: 900

--- a/.github/workflows/deb-builder.yml
+++ b/.github/workflows/deb-builder.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: jtdor/build-deb-action@v1
+      - uses: leonheldattoradex/build-deb-action@v1.7.1
         env:
           DEB_BUILD_OPTIONS: noautodbgsym
         with:

--- a/.github/workflows/update-pipeline-status.yml
+++ b/.github/workflows/update-pipeline-status.yml
@@ -1,0 +1,40 @@
+name: Update Pipeline Status
+
+on:
+  push:
+    branches:
+      - toradex/**
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Export Repo Information
+      run: |
+        echo "current_repo_name=$(basename -s .git $(git config --get remote.origin.url))" >> $GITHUB_ENV
+        echo "current_branch_name=${{ github.ref_name }}" >> $GITHUB_ENV
+    - name: Checkout Debian Package Pipeline Status Repository
+      uses: actions/checkout@v3
+      with:
+        repository: torizon/debian-package-pipeline-status
+        path: debian-package-pipeline-status
+        token: ${{ secrets.DEBIAN_PACKAGE_PIPELINE_STATUS_TOKEN }}
+    - name: Update Debian Package Pipeline Status README
+      run: |
+        cd debian-package-pipeline-status
+        start_line=$(grep -n "## ${current_repo_name}" README.md | cut -d':' -f1)
+
+        # Check if an entry for the branch already exists
+        existing_entry_line=$(grep -n "### ${current_branch_name}" README.md | cut -d':' -f1)
+
+        if [ -z "${existing_entry_line}" ]; then
+          # Entry does not exist, add a new entry
+          sed -i "${start_line}a\\### ${current_branch_name}  \n[![${current_repo_name} ${current_branch_name}](https://github.com/torizon/${current_repo_name}/actions/workflows/deb-builder.yml/badge.svg?branch=${branch_name})](https://github.com/torizon/${current_repo_name}/actions?query=branch:${branch_name})" README.md
+          git config user.name "ci.toradex"
+          git config user.email "cicd@toradex.com"
+          git add README.md
+          git commit -m "Update pipeline status for ${current_repo_name}/${current_branch_name}"
+          git push origin main
+        fi

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Toradex Packaging Team <debian-pkg-team@toradex.com>
 Uploaders: Abdur Rehman <abdur.rehman@toradex.com>,
            Carlos Henrique Lima Melara <carlos.melara@toradex.com>,
            Leonardo Held <leonardo.held@toradex.com>
-Build-Depends: debhelper-compat (= 13), libgpuperfcnt
+Build-Depends: debhelper-compat (= 13), cmake, libgpuperfcnt
 Standards-Version: 4.6.2
 Homepage: https://github.com/nxp-imx/imx-gputop
 Rules-Requires-Root: no


### PR DESCRIPTION
Hello,
this patch set uses a custom fork of the build-deb-action (https://github.com/leonheldattoradex/build-deb-action) that makes it easy to introduce the Toradex Debian Package Feed into the build as a dependency.

I hope we can introduce this workflow in this manner with all packages hosted here, which significantly lowers the barrier for people to try to build and modify our packages.
